### PR TITLE
Make a copy of childNodes before iterating

### DIFF
--- a/katakana-terminator.user.js
+++ b/katakana-terminator.user.js
@@ -34,7 +34,7 @@ function scanTextNodes(node) {
     } else if (excludeTags.test(node.nodeName)) {
         return;
     } else if (node.hasChildNodes()) {
-        return [].forEach.call(node.childNodes, scanTextNodes);
+        return Array.prototype.slice.call(node.childNodes).forEach(scanTextNodes);
     } else if (node.nodeType == 3) {
         while ((node = addRuby(node)));
     }


### PR DESCRIPTION
简单粗暴的 reproduction:

```html
<html>
<body>
カタカナ漢字
<br>
カタカナ漢字
</body>
</html>
```

只有第一行会生效。

原因是 `Node.childNodes` 是 live 的: https://developer.mozilla.org/en-US/docs/Web/API/NodeList#Live_vs._Static_NodeLists

循环里有 `splitText` 和 `appendChild` 于是它就炸了。