### PR TITLE
Even better regex

### DIFF
--- a/katakana-terminator.user.js
+++ b/katakana-terminator.user.js
@@ -44,7 +44,7 @@ function scanTextNodes(node) {
 
 // Inspired by http://www.the-art-of-web.com/javascript/search-highlight/
 function addRuby(node) {
-    var katakana = /[\u30A1-\u30FA\u30FD-\u30FF][\u30A1-\u30FF]*[\u30A1-\u30FA\u30FC-\u30FF]/, match;
+    var katakana = /[\u30A1-\u30FA\u30FD-\u30FF][\u3099\u309A\u30A1-\u30FF]*[\u3099\u309A\u30A1-\u30FA\u30FC-\u30FF]|[\uFF66-\uFF6F\uFF71-\uFF9D][\uFF65-\uFF9F]*[\uFF66-\uFF9F]/, match;
     if (!node.nodeValue || !(match = katakana.exec(node.nodeValue))) {
         return false;
     }


### PR DESCRIPTION
This adds support for Combining Voiced / Semi-Voiced Sound Mark (結合文字濁点 / 半濁点), as well as the halfwidth forms.

Summary of what is matched now:

| | Fullwidth | Halfwidth |
|-|-|-|
| First | カタカナ `\u30A1-\u30FA\u30FD-\u30FF` | カタカナ `\uFF66-\uFF6F\uFF71-\uFF9D` |
| Middle | カタカナ `\u30A1-\u30FA\u30FD-\u30FF`<br>結合文字（半）濁点 `\u3099\u309A`<br>中黒 `\u30FB`<br>長音符 `\u30FC` | カタカナ `\uFF66-\uFF6F\uFF71-\uFF9D`<br>（半）濁点 `\uFF9E\uFF9F`<br>中黒 `\uFF65`<br>長音符 `\uFF70` |
| Last | カタカナ `\u30A1-\u30FA\u30FD-\u30FF`<br>結合文字（半）濁点 `\u3099\u309A`<br>長音符 `\u30FC` | カタカナ `\uFF66-\uFF6F\uFF71-\uFF9D`<br>（半）濁点 `\uFF9E\uFF9F`<br>長音符 `\uFF70` |

This of course introduces some false positive, like if a single 濁音 is written in its NFD form, it will become the base Kana + 結合文字濁点, so we would match it.

Also if something starts with `\u30FD` ヽ or `\u30FE` ヾ, it is definitely broken. But it probably doesn't worth to handle them differently than the normal kanas.