### PR TITLE
添加翻译出的英文字体的大小控制

### DIFF
--- a/katakana-terminator.user.js
+++ b/katakana-terminator.user.js
@@ -51,6 +51,7 @@ function addRuby(node) {
     var ruby = _.createElement('ruby');
     ruby.appendChild(_.createTextNode(match[0]));
     var rt = _.createElement('rt');
+    rt.setAttribute('style', 'font-size: 60%');
     rt.classList.add('katakana-terminator-rt');
     queue[match[0]] = queue[match[0]] || [];
     queue[match[0]].push(rt);


### PR DESCRIPTION
实际使用体验我感觉翻译出来的英文字体太小了，所以加上了这句：
```
rt.setAttribute('style', 'font-size: 60%');
```

这样就可以调整大小了。
如果有更合适的地方也可以麻烦你调整下修改方式。