### PR TITLE
更换到Google Translate API

### DIFF
--- a/katakana-terminator.user.js
+++ b/katakana-terminator.user.js
@@ -14,6 +14,7 @@
 // @grant       GM_xmlhttpRequest
 // @grant       GM_addStyle
 // @connect     translate.google.com
+// @connect     translate.googleapis.com
 // @connect     translate.google.cn
 // @version     2022.01.05
 // @name:ja-JP  カタカナターミネーター
@@ -122,9 +123,10 @@ function googleTranslate(srcLang, destLang, phrases) {
     });
 
     var joinedText = phrases.join('\n').trim(),
-        api = 'https://translate.google.cn/translate_a/t',
+        api = 'https://translate.googleapis.com/translate_a/single',
         params = {
-            client: 'dict-chrome-ex',
+            client: 'gtx',
+            dt: "t",
             sl: srcLang,
             tl: destLang,
             q: joinedText,
@@ -133,12 +135,14 @@ function googleTranslate(srcLang, destLang, phrases) {
         method: "GET",
         url: api + buildQueryString(params),
         onload: function(dom) {
-            JSON.parse(dom.responseText).sentences.forEach(function(s) {
-                if (!s.orig) {
-                    return;
-                }
-                var original = s.orig.trim(),
-                    translated = s.trans.trim();
+            console.log(dom.responseText)
+            let resu = JSON.parse(dom.responseText)
+            console.log(resu)
+            resu[0].forEach(function(item) {
+                console.log(item)
+                let translated = item[0].replace(/\r|\n/ig,"");
+                let original = item[1].replace(/\r|\n/ig,"");
+
                 cachedTranslations[original] = translated;
                 updateRubyByCachedTranslations(original);
             });


### PR DESCRIPTION
实际使用中，发现在一些情况下原本的API返回的数据是随机的，导致使用过程中出现无法正确渲染的情况。
情况一：（能正确返回JSON，这种情况下能正常渲染）
```json
{"sentences":[{"trans":"Hello","orig":"bonjour","backend":10}],"src":"fr","alternative_translations":[{"src_phrase":"bonjour","alternative":[{"word_postproc":"Hello","score":1000,"has_preceding_space":true,"attach_to_next_token":false,"backends":[10,3]},{"word_postproc":"Good morning","score":1000,"has_preceding_space":true,"attach_to_next_token":false,"backends":[10]}],"srcunicodeoffsets":[{"begin":0,"end":7}],"raw_src_segment":"bonjour","start_pos":0,"end_pos":0}],"confidence":0.96875,"ld_result":{"srclangs":["fr"],"srclangs_confidences":[0.96875],"extended_srclangs":["fr"]},"query_inflections":[{"written_form":"bonjour","features":{"number":2}},{"written_form":"bonjours","features":{"number":1}},{"written_form":"bonjour","features":{"gender":1,"number":2}},{"written_form":"bonjours","features":{"gender":1,"number":1}}]}
```
情况二：（返回的是一个只有一个字符串的数组，这种情况下不能正常渲染）
```json
["Bonjour"]
```

经过翻看代码内引用的issue，发现还有另外一个API（即Endpoint是single后缀的）。

经过我的测试（在本地主机和手机上），无论挂不挂梯子都可以访问该Endpoint。

因此，请求切换到该API获取更稳定的使用体验。