### PR TITLE
fix: 一部のカタカナが翻訳できません

### DIFF
--- a/katakana-terminator.user.js
+++ b/katakana-terminator.user.js
@@ -3,7 +3,7 @@
 // @description Convert gairaigo (Japanese loan words) back to English
 // @author      Arnie97
 // @license     MIT
-// @copyright   2017-2021, Katakana Terminator Contributors (https://github.com/Arnie97/katakana-terminator/graphs/contributors)
+// @copyright   2017-2024, Katakana Terminator Contributors (https://github.com/Arnie97/katakana-terminator/graphs/contributors)
 // @namespace   https://github.com/Arnie97
 // @homepageURL https://github.com/Arnie97/katakana-terminator
 // @supportURL  https://greasyfork.org/scripts/33268/feedback
@@ -16,7 +16,7 @@
 // @connect     translate.google.cn
 // @connect     translate.google.com
 // @connect     translate.googleapis.com
-// @version     2022.02.19
+// @version     2024.05.05
 // @name:ja-JP  カタカナターミネーター
 // @name:zh-CN  片假名终结者
 // @description:zh-CN 在网页中的日语外来语上方标注英文原词

--- a/katakana-terminator.user.js
+++ b/katakana-terminator.user.js
@@ -44,7 +44,7 @@ function scanTextNodes(node) {
         if (node.tagName.toLowerCase() in excludeTags || node.isContentEditable) {
             return;
         }
-        return node.childNodes.forEach(scanTextNodes);
+        return Array.from(node.childNodes).forEach(scanTextNodes);
 
     case Node.TEXT_NODE:
         while ((node = addRuby(node)));


### PR DESCRIPTION
原因は node.childNodes を forEach するの同時に、その DOM を変更しているからだ。node.childNodes はライブ配列で、DOM が変更されるたびにその値が変更されます。したがって、これをループする前にコピーを作成することがお勧めします。

ビフォー

![image_2024-05-05_11-07-38](https://github.com/Arnie97/katakana-terminator/assets/26316494/9619f695-ce62-424a-a646-5265e7ff2181)

アフター

![image_2024-05-05_11-08-05](https://github.com/Arnie97/katakana-terminator/assets/26316494/36bb468e-e363-4c3c-8fed-4042563c9b75)
